### PR TITLE
More faithful quadratic bezier conversion

### DIFF
--- a/src/svg.pathmorphing.js
+++ b/src/svg.pathmorphing.js
@@ -223,8 +223,6 @@ function toBeziere(val){
       val[5] = val[3]
       val[4] = val[2]
       val[3] = val[1]
-      val[2] = this.pos[1]
-      val[1] = this.pos[0]
       break
     case 'A':
       throw 'Cant morph arcs to beziere'


### PR DESCRIPTION
Quadratic bezier should retain first control point when converting to cubic, and just duplicate it as the second control point.

Reference for Q commands:
> It requires one control point which determines the slope of the curve at both the start point and the end point.
https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#Bezier_Curves